### PR TITLE
Update ignore file and ignore IDE0058

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,7 @@ _reports
 _UpgradeReport_Files/
 artifacts/
 Backup*/
-BenchmarkDotNet.Artifacts/
+BenchmarkDotNet.Artifacts*/
 bin
 Bin
 coverage

--- a/src/DotNetBenchmarks/DotNetBenchmarks.csproj
+++ b/src/DotNetBenchmarks/DotNetBenchmarks.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <NoWarn>$(NoWarn);SA1600</NoWarn>
+    <NoWarn>$(NoWarn);IDE0058;SA1600</NoWarn>
     <OutputType>Exe</OutputType>
     <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>


### PR DESCRIPTION
- Prefix excluding `BenchmarkDotNet.Artifacts` to allow for local copy-paste to keep results when experimenting.
- Ignore any IDE0058 warnings.
